### PR TITLE
Add "hotspotarriva" to RF emitter blacklist

### DIFF
--- a/app/src/main/java/org/fitchfamily/android/dejavu/RfEmitter.kt
+++ b/app/src/main/java/org/fitchfamily/android/dejavu/RfEmitter.kt
@@ -326,6 +326,7 @@ class RfEmitter(val type: EmitterType, val id: String) {
                 || lcSplit.contains("moto") && note.startsWith("MOTO") // "MOTO9564" and "MOTO9916" seen
                 || lcSplit.first() == "audi"            // some cars seem to have this AP on-board
                 || lc == macSuffix                      // Apparent default SSID name for many cars
+                || lcSplit.first() == "hotspotarriva"   // transport
                 // deal with words not achievable with the blacklist sets, checking only if
                 // lcSplit.contains(<something>) (for performance reasons)
                 || (lcSplit.contains("admin") && lc.contains("admin@ms"))


### PR DESCRIPTION
First of all, I want to say that it's great that development is being continued on such a useful tool as Dejavu, very nice

Today I was testing this tool out while traveling with the public transport in the Netherlands, and after exporting the data I found many entries called either `HotspotArriva_L_xxxx` or `HotspotArriva_xxxx` where `L` can be any letter and `x` can be any number. Arriva is a public transport company and provides moving public internet hotspots in their buses which are named in this scheme.

This case should select it. I also thought of adding `&& note.startsWith("HotspotArriva")`, but I think the chance is very low that this case matches other WiFi networks, so I left it out.

